### PR TITLE
rename some functions and break the API for better behavior

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -55,19 +55,26 @@ func UnmarshalTCPHeader(data []byte) (*TCPHeader, error) {
 	return unmarshalTCPHeader(data)
 }
 
-// MarshalNoChecksum is a function to marshal the *TCPHeader instance to a byte slice
+// Marshal is a function to marshal the *TCPHeader instance to a byte slice
 // without explicitly calculating the checksum for the data. Because there is no
 // checksumming of the data, the local and remote addresses are not required.
 //
-// If the *TCPHeader instance has the Checksum field set, it will be included in the
-// marshaled data.
-func (tcp *TCPHeader) MarshalNoChecksum() ([]byte, error) {
+// To note, if the checksum is not provided (i.e. 0) the kernel SHOULD automatically
+// calculate this for you.
+//
+// However, if the *TCPHeader instance has the Checksum field set, it will be
+// included in the marshaled data.
+func (tcp *TCPHeader) Marshal() ([]byte, error) {
 	return tcp.marshalTCPHeader()
 }
 
-// Marshal is a function to marshal the TCPHeader to a byte slice for sending
-// across the network.
-func (tcp *TCPHeader) Marshal(laddr, raddr string) ([]byte, error) {
+// MarshalWithChecksum is a function to marshal the TCPHeader to a byte slice.
+// This function is almost the same as Marshal() However, this calculates also
+// the TCP checksum and adds it to the header / marshaled data.
+//
+// It's suggested that you use Marshal() instead and offload the
+// checksumming to your kernel (which should do it automatically if not present).
+func (tcp *TCPHeader) MarshalWithChecksum(laddr, raddr string) ([]byte, error) {
 	// marshal the header
 	data, err := tcp.marshalTCPHeader()
 

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -136,11 +136,11 @@ func (t *TestSuite) TestChecksumIPv4(c *C) {
 	c.Check(csum, Equals, uint16(0xfb59))
 }
 
-func (t *TestSuite) TestMarshalNoChecksum(c *C) {
+func (t *TestSuite) TestMarshal(c *C) {
 	var data []byte
 	var err error
 
-	data, err = t.t.MarshalNoChecksum()
+	data, err = t.t.Marshal()
 	c.Assert(err, IsNil)
 	c.Assert(data, Not(IsNil))
 
@@ -193,11 +193,11 @@ func (t *TestSuite) TestMarshalNoChecksum(c *C) {
 	c.Check(u16, Equals, uint16(0))
 }
 
-func (t *TestSuite) TestMarshal(c *C) {
+func (t *TestSuite) TestMarshalWithChecksum(c *C) {
 	var data []byte
 	var err error
 
-	data, err = t.t.Marshal("127.0.0.1", "127.0.0.2")
+	data, err = t.t.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
 	c.Assert(err, IsNil)
 	c.Assert(data, Not(IsNil))
 
@@ -256,7 +256,7 @@ func (t *TestSuite) TestMarshal(c *C) {
 
 	t.t.DataOffset = 0
 
-	data, err = t.t.Marshal("127.0.0.1", "127.0.0.2")
+	data, err = t.t.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
 	c.Assert(err, IsNil)
 	c.Assert(data, Not(IsNil))
 
@@ -311,7 +311,7 @@ func (t *TestSuite) TestMarshal(c *C) {
 
 	t.t.DataOffset = 3
 
-	data, err = t.t.Marshal("127.0.0.1", "127.0.0.2")
+	data, err = t.t.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
 	c.Assert(err, Not(IsNil))
 	c.Check(data, IsNil)
 
@@ -329,7 +329,7 @@ func (t *TestSuite) TestMarshal(c *C) {
 
 	t.t.WindowSize = 0
 
-	data, err = t.t.Marshal("127.0.0.1", "127.0.0.2")
+	data, err = t.t.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
 	c.Assert(err, IsNil)
 	c.Assert(data, Not(IsNil))
 


### PR DESCRIPTION
Making the checksummed function the default was not needed. The kernel should automatically calculate the checksum if none are present.

As such the old `Marshal()` function is now `MarshalWithChecksum()` while `MarshalNoChecksum()` is now `Marshal()`. Tests were updated as well.
