### PR TITLE
add padding functionality to the marshaling code

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -6,11 +6,22 @@ package packets
 
 // DataOffsetInvalid is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. You can type assert against it to handle that input
-// differently
+// differently.
 type DataOffsetInvalid struct {
 	E string
 }
 
 func (e DataOffsetInvalid) Error() string {
+	return e.E
+}
+
+// DataOffsetTooSmall is a type that implements the error interface. It's used for errors
+// marshaling the TCPHeader data. Specifically, this is used when the DataOffset is too small
+// for the amount of data in the TCP header.
+type DataOffsetTooSmall struct {
+	E string
+}
+
+func (e DataOffsetTooSmall) Error() string {
 	return e.E
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -16,3 +16,11 @@ func (t *TestSuite) TestDataOffsetInvalid_Error(c *C) {
 
 	c.Assert(e.Error(), Equals, "test message")
 }
+
+func (t *TestSuite) TestDataOffsetTooSmall_Error(c *C) {
+	var e packets.DataOffsetTooSmall
+
+	e = packets.DataOffsetTooSmall{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}


### PR DESCRIPTION
TCP packets should be padded with null (`0x00`) bytes to the nearest 32-bit boundary. With the current implementation this shouldn't really ever be used. However, once TCP options and the ability to attach a payload is added this will come in handy.
