### PR TITLE
add support for TCP Options header field

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,24 +4,57 @@
 
 package packets
 
-// DataOffsetInvalid is a type that implements the error interface. It's used for errors
+// TCPDataOffsetInvalid is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. You can type assert against it to handle that input
 // differently.
-type DataOffsetInvalid struct {
+type TCPDataOffsetInvalid struct {
 	E string
 }
 
-func (e DataOffsetInvalid) Error() string {
+func (e TCPDataOffsetInvalid) Error() string {
 	return e.E
 }
 
-// DataOffsetTooSmall is a type that implements the error interface. It's used for errors
+// TCPDataOffsetTooSmall is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the DataOffset is too small
 // for the amount of data in the TCP header.
-type DataOffsetTooSmall struct {
+type TCPDataOffsetTooSmall struct {
 	E string
 }
 
-func (e DataOffsetTooSmall) Error() string {
+func (e TCPDataOffsetTooSmall) Error() string {
+	return e.E
+}
+
+// TCPOptionsOverflow is a type that implements the error interface. It's used for errors
+// marshaling the TCPHeader data. Specifically, this is used when the TCP Options field exceeds
+// its maximum length as specified by the RFC.
+type TCPOptionsOverflow struct {
+	E string
+}
+
+func (e TCPOptionsOverflow) Error() string {
+	return e.E
+}
+
+// TCPOptionDataInvalid is a type that implements the error interface. It's used for errors
+// marshaling the TCPHeader data. Specifically, this is used when the TCP Options Length field
+// doesn't match the data provided.
+type TCPOptionDataInvalid struct {
+	E string
+}
+
+func (e TCPOptionDataInvalid) Error() string {
+	return e.E
+}
+
+// TCPOptionDataTooLong is a type that implements the error interface. It's used for errors
+// marshaling the TCPHeader data. Specifically, this is use for when the TCP Options Data field is
+// too long for the Options field as per the RFC.
+type TCPOptionDataTooLong struct {
+	E string
+}
+
+func (e TCPOptionDataTooLong) Error() string {
 	return e.E
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,17 +10,41 @@ import (
 )
 
 func (t *TestSuite) TestDataOffsetInvalid_Error(c *C) {
-	var e packets.DataOffsetInvalid
+	var e packets.TCPDataOffsetInvalid
 
-	e = packets.DataOffsetInvalid{E: "test message"}
+	e = packets.TCPDataOffsetInvalid{E: "test message"}
 
 	c.Assert(e.Error(), Equals, "test message")
 }
 
 func (t *TestSuite) TestDataOffsetTooSmall_Error(c *C) {
-	var e packets.DataOffsetTooSmall
+	var e packets.TCPDataOffsetTooSmall
 
-	e = packets.DataOffsetTooSmall{E: "test message"}
+	e = packets.TCPDataOffsetTooSmall{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}
+
+func (t *TestSuite) TestOptionsOverflow_Error(c *C) {
+	var e packets.TCPOptionsOverflow
+
+	e = packets.TCPOptionsOverflow{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}
+
+func (t *TestSuite) TestOptionDataInvalid_Error(c *C) {
+	var e packets.TCPOptionDataInvalid
+
+	e = packets.TCPOptionDataInvalid{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}
+
+func (t *TestSuite) TestOptionDataTooLong_Error(c *C) {
+	var e packets.TCPOptionDataTooLong
+
+	e = packets.TCPOptionDataTooLong{E: "test message"}
 
 	c.Assert(e.Error(), Equals, "test message")
 }

--- a/tcp.go
+++ b/tcp.go
@@ -25,7 +25,32 @@ const (
 	rstBit uint16 = 4   // RST
 	synBit uint16 = 2   // SYN
 	finBit uint16 = 1   // FIN
+
+	tcpHeaderMinSize int = 20
+	tcpOptsMaxSize   int = 40
 )
+
+// TCPOption is a struct to hold the data for the various options available for the TCP
+// header. See this Wikipedia article for more information:
+//
+// https://en.wikipedia.org/wiki/Transmission_Control_Protocol#TCP_segment_structure
+//
+// The struct fields should be fairly self-explanatory after reading the above. To note,
+// in all cases the Length field should be equal to 2 + len(Data). This is because the
+// Length field, per the RFC, must count itself and the Kind field (which are both
+// one byte).
+//
+//As a convenience, if the Length is set to zero it will be automatically
+// calculated and set at the time of marshaling.
+type TCPOption struct {
+	Kind   uint8
+	Length uint8
+	Data   []byte
+}
+
+// TCPOptionSlice is a slice of TCPOptions for use in the TCPHeader
+// Options field.
+type TCPOptionSlice []*TCPOption
 
 // TCPHeader is a struct representing a TCP header. The options portion
 // of the TCP header is not implemented in this struct.
@@ -38,7 +63,7 @@ type TCPHeader struct {
 	DestinationPort uint16
 	SeqNum          uint32
 	AckNum          uint32
-	DataOffset      uint8 // should be either 0 or >= 5 or <=15 (default: 5)
+	DataOffset      uint8 // should be either 0 or >= 5 or <=15 (default: 5); if 0 will be auto-set
 	Reserved        uint8 // this should always be 0
 	NS              bool
 	CWR             bool
@@ -52,10 +77,11 @@ type TCPHeader struct {
 	WindowSize      uint16 // if set to 0 this becomes 65535
 	Checksum        uint16 // suggest setting this to 0 thus offloading to the kernel
 	UrgentPointer   uint16
+	Options         TCPOptionSlice // optional TCP options; see TCPOption comment for more info
 }
 
 // UnmarshalTCPHeader is a function that takes a byte slice and parses it in to an
-// instance of *TCPHeader.
+// instance of *TCPHeader. This also assumes the packet is properly formatted.
 func UnmarshalTCPHeader(data []byte) (*TCPHeader, error) {
 	return unmarshalTCPHeader(data)
 }
@@ -106,6 +132,65 @@ func (tcp *TCPHeader) MarshalWithChecksum(laddr, raddr string) ([]byte, error) {
 	return fullData, nil
 }
 
+// Marshal is a method to marshal the TCPOptionSlice to the raw bytes for use
+// in the TCPHeader.Marshal() method. It's exported mainly for convenience as
+// marsahling uses this function itself.
+func (tcpos TCPOptionSlice) Marshal() ([]byte, error) {
+	buf := new(bytes.Buffer)
+
+	for index, opt := range tcpos {
+		// yeah, make sure this shit isn't nil
+		if opt == nil {
+			continue
+		}
+
+		switch opt.Kind {
+		case 0:
+			if buf.Len() == 0 {
+				return make([]byte, 0), nil
+			}
+			fallthrough
+		case 1:
+			binary.Write(buf, binary.BigEndian, opt.Kind)
+		default:
+			// make sure we're not going to overflow the uint8 Length field
+			if len(opt.Data)+2 > 255 {
+				return nil, TCPOptionDataTooLong{
+					E: fmt.Sprintf("Option %d Data cannot be larger than 253 bytes", index),
+				}
+			}
+
+			// if the option's Length is zero: auto-calculate the value for that field
+			// otherwise: validate that the Length is len(opt.Data) + 2
+			if opt.Length == 0 {
+				opt.Length = uint8(len(opt.Data)) + 2
+			} else if uint8(len(opt.Data))+2 != opt.Length {
+				return nil, TCPOptionDataInvalid{
+					E: fmt.Sprintf("Option %d Length doesn't match length of data", index),
+				}
+			}
+
+			binary.Write(buf, binary.BigEndian, opt.Kind)
+			binary.Write(buf, binary.BigEndian, opt.Length)
+			binary.Write(buf, binary.BigEndian, opt.Data)
+
+			// if there looks to be no more options just continue through
+			// to avoid erroneous padding of the data
+			if len(tcpos)-1 == index {
+				continue
+			}
+
+			// if this isn't the last option, pad to the nearest
+			// 32-bit boundary using ones (1)
+			for i := 0; i < buf.Len()%4; i++ {
+				binary.Write(buf, binary.BigEndian, uint8(1))
+			}
+		}
+	}
+
+	return buf.Bytes(), nil
+}
+
 // ChecksumIPv4 is a function for computing the TCP checksum of an IPv4 packet.
 func ChecksumIPv4(data []byte, laddr, raddr string) uint16 {
 	// convert the IP address strings to their byte equivalents
@@ -128,75 +213,6 @@ func ChecksumIPv4(data []byte, laddr, raddr string) uint16 {
 	pHeader.Write(data)
 
 	return checksum(pHeader.Bytes())
-}
-
-func (tcp *TCPHeader) marshalTCPHeader() ([]byte, error) {
-	// if the field is the type's default, and an obviously invalid value
-	// then just set it to the bare minimum for the TCP header.
-	if tcp.DataOffset == 0 {
-		tcp.DataOffset = 5
-	}
-
-	// if the offset is outside of the acceptable range
-	// fail with a DataOffsetInvalid error
-	if tcp.DataOffset > 15 || tcp.DataOffset < 5 {
-		return nil, DataOffsetInvalid{
-			E: "DataOffset field must be at least 5 and no more than 15",
-		}
-	}
-
-	// if the WindowSize field is the default let's set it to something better
-	if tcp.WindowSize == 0 {
-		tcp.WindowSize = 65535
-	}
-
-	// build the DataOffset, Reserved, and Control Flags data
-	ctrl := uint16(tcp.DataOffset)<<12 |
-		uint16(tcp.Reserved)<<9 |
-		ctrlBitSet(tcp.NS, nsBit) |
-		ctrlBitSet(tcp.CWR, cwrBit) |
-		ctrlBitSet(tcp.ECE, eceBit) |
-		ctrlBitSet(tcp.URG, urgBit) |
-		ctrlBitSet(tcp.ACK, ackBit) |
-		ctrlBitSet(tcp.PSH, pshBit) |
-		ctrlBitSet(tcp.RST, rstBit) |
-		ctrlBitSet(tcp.SYN, synBit) |
-		ctrlBitSet(tcp.FIN, finBit)
-
-	buf := new(bytes.Buffer)
-
-	// write all the data to the byte buffer
-	binary.Write(buf, binary.BigEndian, tcp.SourcePort)
-	binary.Write(buf, binary.BigEndian, tcp.DestinationPort)
-	binary.Write(buf, binary.BigEndian, tcp.SeqNum)
-	binary.Write(buf, binary.BigEndian, tcp.AckNum)
-	binary.Write(buf, binary.BigEndian, ctrl)
-	binary.Write(buf, binary.BigEndian, tcp.WindowSize)
-	binary.Write(buf, binary.BigEndian, tcp.Checksum)
-	binary.Write(buf, binary.BigEndian, tcp.UrgentPointer)
-
-	// each offset is 4 bytes long so figure out how many bytes of padding
-	// we should have (based on the DataOffset size) to line up with the 32-bit
-	// boundary
-	totalPad := int(tcp.DataOffset*4) - buf.Len()
-
-	// DataOffset is too small for the amount of data in the header
-	if totalPad < 0 {
-		doSize := int(math.Ceil(float64(buf.Len()) / 4))
-		return nil, DataOffsetTooSmall{
-			E: fmt.Sprintf(
-				"The DataOffset field is too small for the data provided. It should be at least %d",
-				doSize,
-			),
-		}
-	}
-
-	// pad the end of the packet with null bytes to the 32-bit boundary
-	for i := 0; i < totalPad; i++ {
-		binary.Write(buf, binary.BigEndian, uint8(0))
-	}
-
-	return buf.Bytes(), nil
 }
 
 func checksum(data []byte) uint16 {
@@ -258,6 +274,99 @@ func ctrlBitValue(ctrl uint16, bit uint16) bool {
 	return false
 }
 
+func optionsLen(opts []TCPOption) (count int) {
+	for _, opt := range opts {
+		count += int(opt.Length)
+	}
+	return
+}
+
+func (tcp *TCPHeader) marshalTCPHeader() ([]byte, error) {
+	optBytes, err := tcp.Options.Marshal()
+
+	if err != nil {
+		return nil, err
+	}
+
+	// if the calculated length of the options is too large
+	// return an error
+	if len(optBytes) > tcpOptsMaxSize {
+		return nil, TCPOptionsOverflow{
+			E: fmt.Sprintf("TCP Options are too large, must be less than %d total bytes", tcpOptsMaxSize),
+		}
+	}
+
+	dataOffsetSize := uint8(math.Ceil(float64(tcpHeaderMinSize+len(optBytes)) / 4))
+
+	// if the field is the type's default, and an obviously invalid value
+	// then just set it to the bare minimum for the TCP header.
+	if tcp.DataOffset == 0 {
+		tcp.DataOffset = dataOffsetSize
+	}
+
+	// if the offset is outside of the acceptable range
+	// fail with a DataOffsetInvalid error
+	if tcp.DataOffset > 15 || tcp.DataOffset < 5 {
+		return nil, TCPDataOffsetInvalid{
+			E: "DataOffset field must be at least 5 and no more than 15",
+		}
+	}
+
+	// if the WindowSize field is the default let's set it to something better
+	if tcp.WindowSize == 0 {
+		tcp.WindowSize = 65535
+	}
+
+	// build the DataOffset, Reserved, and Control Flags data
+	ctrl := uint16(tcp.DataOffset)<<12 |
+		uint16(tcp.Reserved)<<9 |
+		ctrlBitSet(tcp.NS, nsBit) |
+		ctrlBitSet(tcp.CWR, cwrBit) |
+		ctrlBitSet(tcp.ECE, eceBit) |
+		ctrlBitSet(tcp.URG, urgBit) |
+		ctrlBitSet(tcp.ACK, ackBit) |
+		ctrlBitSet(tcp.PSH, pshBit) |
+		ctrlBitSet(tcp.RST, rstBit) |
+		ctrlBitSet(tcp.SYN, synBit) |
+		ctrlBitSet(tcp.FIN, finBit)
+
+	buf := new(bytes.Buffer)
+
+	// write all the data to the byte buffer
+	binary.Write(buf, binary.BigEndian, tcp.SourcePort)
+	binary.Write(buf, binary.BigEndian, tcp.DestinationPort)
+	binary.Write(buf, binary.BigEndian, tcp.SeqNum)
+	binary.Write(buf, binary.BigEndian, tcp.AckNum)
+	binary.Write(buf, binary.BigEndian, ctrl)
+	binary.Write(buf, binary.BigEndian, tcp.WindowSize)
+	binary.Write(buf, binary.BigEndian, tcp.Checksum)
+	binary.Write(buf, binary.BigEndian, tcp.UrgentPointer)
+
+	buf.Write(optBytes)
+
+	// each offset is 4 bytes long so figure out how many bytes of padding
+	// we should have (based on the DataOffset size) to line up with the 32-bit
+	// boundary
+	totalPad := int(tcp.DataOffset*4) - buf.Len()
+
+	// DataOffset is too small for the amount of data in the header
+	if totalPad < 0 {
+		return nil, TCPDataOffsetTooSmall{
+			E: fmt.Sprintf(
+				"The DataOffset field is too small for the data provided. It should be at least %d",
+				dataOffsetSize,
+			),
+		}
+	}
+
+	// pad the end of the packet with null bytes to the 32-bit boundary
+	for i := 0; i < totalPad; i++ {
+		binary.Write(buf, binary.BigEndian, uint8(0))
+	}
+
+	return buf.Bytes(), nil
+}
+
 func unmarshalTCPHeader(data []byte) (*TCPHeader, error) {
 	var header TCPHeader
 	var ctrl uint16
@@ -265,14 +374,45 @@ func unmarshalTCPHeader(data []byte) (*TCPHeader, error) {
 	reader := bytes.NewReader(data)
 
 	// pull all the fields from the data
-	binary.Read(reader, binary.BigEndian, &header.SourcePort)
-	binary.Read(reader, binary.BigEndian, &header.DestinationPort)
-	binary.Read(reader, binary.BigEndian, &header.SeqNum)
-	binary.Read(reader, binary.BigEndian, &header.AckNum)
-	binary.Read(reader, binary.BigEndian, &ctrl)
-	binary.Read(reader, binary.BigEndian, &header.WindowSize)
-	binary.Read(reader, binary.BigEndian, &header.Checksum)
-	binary.Read(reader, binary.BigEndian, &header.UrgentPointer)
+	err := binary.Read(reader, binary.BigEndian, &header.SourcePort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.DestinationPort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.SeqNum)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.AckNum)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &ctrl)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.WindowSize)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.Checksum)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.UrgentPointer)
+	if err != nil {
+		return nil, err
+	}
 
 	header.DataOffset = uint8(ctrl >> 12)
 	header.Reserved = uint8(ctrl >> 9 & 7)
@@ -289,6 +429,60 @@ func unmarshalTCPHeader(data []byte) (*TCPHeader, error) {
 	header.RST = ctrlBitValue(ctrl, rstBit)
 	header.SYN = ctrlBitValue(ctrl, synBit)
 	header.FIN = ctrlBitValue(ctrl, finBit)
+
+	if header.DataOffset > 5 {
+		var d uint8
+		opts := make(TCPOptionSlice, 0)
+
+		for i := 0; i < len(data)-20; i += 0 {
+			var opt TCPOption
+
+			// read the Option-Kind field.
+			err = binary.Read(reader, binary.BigEndian, &d)
+			if err != nil {
+				return nil, err
+			}
+
+			switch d {
+			case 0:
+				break
+			case 1:
+				i++
+				continue
+			default:
+				// set the Kind field to the Option-Kind value
+				opt.Kind = d
+
+				// read off the Option-Length field and set it
+				err = binary.Read(reader, binary.BigEndian, &d)
+				if err != nil {
+					return nil, err
+				}
+
+				opt.Length = d
+
+				// figure out how much data there is to read,
+				// allocate a byte slice for it, and read it
+				optionData := make([]byte, int(opt.Length-2))
+
+				err = binary.Read(reader, binary.BigEndian, &optionData)
+				if err != nil {
+					return nil, err
+				}
+
+				// set the Data from the Option-Data field
+				// and append this option to the TCPOptionSlice
+				opt.Data = optionData
+				opts = append(opts, &opt)
+
+				// increment the counter with the number of byte reads
+				i = int(uint8(i) + opt.Length)
+			}
+
+		}
+
+		header.Options = opts
+	}
 
 	return &header, nil
 }


### PR DESCRIPTION
This adds support for the Options field of a TCP header. This includes the marshaling and unmarshaling of the data. It also handles all of the padding when marshaling.
