### PR TITLE
rename error types for clarity; add further tests around marshaling TCP

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,57 +4,57 @@
 
 package packets
 
-// TCPDataOffsetInvalid is a type that implements the error interface. It's used for errors
+// ErrTCPDataOffsetInvalid is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. You can type assert against it to handle that input
 // differently.
-type TCPDataOffsetInvalid struct {
+type ErrTCPDataOffsetInvalid struct {
 	E string
 }
 
-func (e TCPDataOffsetInvalid) Error() string {
+func (e ErrTCPDataOffsetInvalid) Error() string {
 	return e.E
 }
 
-// TCPDataOffsetTooSmall is a type that implements the error interface. It's used for errors
+// ErrTCPDataOffsetTooSmall is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the DataOffset is too small
 // for the amount of data in the TCP header.
-type TCPDataOffsetTooSmall struct {
+type ErrTCPDataOffsetTooSmall struct {
 	E string
 }
 
-func (e TCPDataOffsetTooSmall) Error() string {
+func (e ErrTCPDataOffsetTooSmall) Error() string {
 	return e.E
 }
 
-// TCPOptionsOverflow is a type that implements the error interface. It's used for errors
+// ErrTCPOptionsOverflow is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the TCP Options field exceeds
 // its maximum length as specified by the RFC.
-type TCPOptionsOverflow struct {
+type ErrTCPOptionsOverflow struct {
 	E string
 }
 
-func (e TCPOptionsOverflow) Error() string {
+func (e ErrTCPOptionsOverflow) Error() string {
 	return e.E
 }
 
-// TCPOptionDataInvalid is a type that implements the error interface. It's used for errors
+// ErrTCPOptionDataInvalid is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the TCP Options Length field
 // doesn't match the data provided.
-type TCPOptionDataInvalid struct {
+type ErrTCPOptionDataInvalid struct {
 	E string
 }
 
-func (e TCPOptionDataInvalid) Error() string {
+func (e ErrTCPOptionDataInvalid) Error() string {
 	return e.E
 }
 
-// TCPOptionDataTooLong is a type that implements the error interface. It's used for errors
+// ErrTCPOptionDataTooLong is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is use for when the TCP Options Data field is
 // too long for the Options field as per the RFC.
-type TCPOptionDataTooLong struct {
+type ErrTCPOptionDataTooLong struct {
 	E string
 }
 
-func (e TCPOptionDataTooLong) Error() string {
+func (e ErrTCPOptionDataTooLong) Error() string {
 	return e.E
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -9,42 +9,42 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (t *TestSuite) TestDataOffsetInvalid_Error(c *C) {
-	var e packets.TCPDataOffsetInvalid
+func (t *TestSuite) TestErrTCPDataOffsetInvalid_Error(c *C) {
+	var e packets.ErrTCPDataOffsetInvalid
 
-	e = packets.TCPDataOffsetInvalid{E: "test message"}
-
-	c.Assert(e.Error(), Equals, "test message")
-}
-
-func (t *TestSuite) TestDataOffsetTooSmall_Error(c *C) {
-	var e packets.TCPDataOffsetTooSmall
-
-	e = packets.TCPDataOffsetTooSmall{E: "test message"}
+	e = packets.ErrTCPDataOffsetInvalid{E: "test message"}
 
 	c.Assert(e.Error(), Equals, "test message")
 }
 
-func (t *TestSuite) TestOptionsOverflow_Error(c *C) {
-	var e packets.TCPOptionsOverflow
+func (t *TestSuite) TestErrTCPDataOffsetTooSmall_Error(c *C) {
+	var e packets.ErrTCPDataOffsetTooSmall
 
-	e = packets.TCPOptionsOverflow{E: "test message"}
-
-	c.Assert(e.Error(), Equals, "test message")
-}
-
-func (t *TestSuite) TestOptionDataInvalid_Error(c *C) {
-	var e packets.TCPOptionDataInvalid
-
-	e = packets.TCPOptionDataInvalid{E: "test message"}
+	e = packets.ErrTCPDataOffsetTooSmall{E: "test message"}
 
 	c.Assert(e.Error(), Equals, "test message")
 }
 
-func (t *TestSuite) TestOptionDataTooLong_Error(c *C) {
-	var e packets.TCPOptionDataTooLong
+func (t *TestSuite) TestErrTCPOptionsOverflow_Error(c *C) {
+	var e packets.ErrTCPOptionsOverflow
 
-	e = packets.TCPOptionDataTooLong{E: "test message"}
+	e = packets.ErrTCPOptionsOverflow{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}
+
+func (t *TestSuite) TestErrTCPOptionDataInvalid_Error(c *C) {
+	var e packets.ErrTCPOptionDataInvalid
+
+	e = packets.ErrTCPOptionDataInvalid{E: "test message"}
+
+	c.Assert(e.Error(), Equals, "test message")
+}
+
+func (t *TestSuite) TestErrTCPOptionDataTooLong_Error(c *C) {
+	var e packets.ErrTCPOptionDataTooLong
+
+	e = packets.ErrTCPOptionDataTooLong{E: "test message"}
 
 	c.Assert(e.Error(), Equals, "test message")
 }

--- a/tcp.go
+++ b/tcp.go
@@ -155,7 +155,7 @@ func (tcpos TCPOptionSlice) Marshal() ([]byte, error) {
 		default:
 			// make sure we're not going to overflow the uint8 Length field
 			if len(opt.Data)+2 > 255 {
-				return nil, TCPOptionDataTooLong{
+				return nil, ErrTCPOptionDataTooLong{
 					E: fmt.Sprintf("Option %d Data cannot be larger than 253 bytes", index),
 				}
 			}
@@ -165,7 +165,7 @@ func (tcpos TCPOptionSlice) Marshal() ([]byte, error) {
 			if opt.Length == 0 {
 				opt.Length = uint8(len(opt.Data)) + 2
 			} else if uint8(len(opt.Data))+2 != opt.Length {
-				return nil, TCPOptionDataInvalid{
+				return nil, ErrTCPOptionDataInvalid{
 					E: fmt.Sprintf("Option %d Length doesn't match length of data", index),
 				}
 			}
@@ -291,7 +291,7 @@ func (tcp *TCPHeader) marshalTCPHeader() ([]byte, error) {
 	// if the calculated length of the options is too large
 	// return an error
 	if len(optBytes) > tcpOptsMaxSize {
-		return nil, TCPOptionsOverflow{
+		return nil, ErrTCPOptionsOverflow{
 			E: fmt.Sprintf("TCP Options are too large, must be less than %d total bytes", tcpOptsMaxSize),
 		}
 	}
@@ -307,7 +307,7 @@ func (tcp *TCPHeader) marshalTCPHeader() ([]byte, error) {
 	// if the offset is outside of the acceptable range
 	// fail with a DataOffsetInvalid error
 	if tcp.DataOffset > 15 || tcp.DataOffset < 5 {
-		return nil, TCPDataOffsetInvalid{
+		return nil, ErrTCPDataOffsetInvalid{
 			E: "DataOffset field must be at least 5 and no more than 15",
 		}
 	}
@@ -351,7 +351,7 @@ func (tcp *TCPHeader) marshalTCPHeader() ([]byte, error) {
 
 	// DataOffset is too small for the amount of data in the header
 	if totalPad < 0 {
-		return nil, TCPDataOffsetTooSmall{
+		return nil, ErrTCPDataOffsetTooSmall{
 			E: fmt.Sprintf(
 				"The DataOffset field is too small for the data provided. It should be at least %d",
 				dataOffsetSize,


### PR DESCRIPTION
This renames the errors types by prefixing them with `Err` to indicate their purpose.

In addition, I realized there were some missing assertions for failure modes of marshaling a TCP header so I added those assertions as well.
