### PR TITLE
add UDP packet creation support; modify ChecksumIPv4 to include kind

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -58,3 +58,23 @@ type ErrTCPOptionDataTooLong struct {
 func (e ErrTCPOptionDataTooLong) Error() string {
 	return e.E
 }
+
+// ErrUDPPayloadTooLarge is a type that implements the error interface. It's used for errors
+// marshaling the UDPHeader data. Specifically, this is use for when the UDP payload is too large.
+type ErrUDPPayloadTooLarge struct {
+	E string
+}
+
+func (e ErrUDPPayloadTooLarge) Error() string {
+	return e.E
+}
+
+// ErrChecksumInvalidKind is a type that implements the error interface. It's used when
+// an invalid packet kind is provided to the ChecksumIPv4 function.
+type ErrChecksumInvalidKind struct {
+	E string
+}
+
+func (e ErrChecksumInvalidKind) Error() string {
+	return e.E
+}

--- a/packets.go
+++ b/packets.go
@@ -1,0 +1,66 @@
+package packets
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// ChecksumIPv4 is a function for computing the TCP checksum of an IPv4 packet. The kind
+// field is either 'tcp' or 'udp' and returns an error if invalid input is given.
+//
+// The returned error type may be ErrChecksumInvalidKind if an invalid kind field
+// is provided.
+func ChecksumIPv4(data []byte, kind, laddr, raddr string) (uint16, error) {
+	// convert the IP address strings to their byte equivalents
+	srcBytes, dstBytes := ipv4AddrToBytes(laddr), ipv4AddrToBytes(raddr)
+
+	var protocol uint8
+
+	switch kind {
+	case "tcp", "TCP":
+		protocol = 6
+	case "udp", "UDP":
+		protocol = 17
+	default:
+		return 0, ErrChecksumInvalidKind{
+			E: "Checksum kind should either be 'tcp' OR 'udp'.",
+		}
+	}
+
+	// create a pseudo header for the packet checksumming
+	pHeader := new(bytes.Buffer)
+
+	binary.Write(pHeader, binary.BigEndian, srcBytes[0])
+	binary.Write(pHeader, binary.BigEndian, srcBytes[1])
+	binary.Write(pHeader, binary.BigEndian, srcBytes[2])
+	binary.Write(pHeader, binary.BigEndian, srcBytes[3])
+	binary.Write(pHeader, binary.BigEndian, dstBytes[0])
+	binary.Write(pHeader, binary.BigEndian, dstBytes[1])
+	binary.Write(pHeader, binary.BigEndian, dstBytes[2])
+	binary.Write(pHeader, binary.BigEndian, dstBytes[3])
+	binary.Write(pHeader, binary.BigEndian, uint8(0))
+	binary.Write(pHeader, binary.BigEndian, protocol)
+	binary.Write(pHeader, binary.BigEndian, uint16(len(data)))
+	pHeader.Write(data)
+
+	return checksum(pHeader.Bytes()), nil
+}
+
+func checksum(data []byte) uint16 {
+	dataSize := len(data) - 1
+
+	var sum uint32
+
+	for i := 0; i+1 < dataSize; i += 2 {
+		sum += uint32(data[i+1])<<8 | uint32(data[i])
+	}
+
+	if dataSize&1 == 1 {
+		sum += uint32(data[dataSize])
+	}
+
+	sum = sum>>16 + sum&0xffff
+	sum = sum + sum>>16
+
+	return ^uint16(sum)
+}

--- a/packets_test.go
+++ b/packets_test.go
@@ -1,0 +1,140 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package packets_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"testing"
+
+	"github.com/theckman/packets"
+	. "gopkg.in/check.v1"
+)
+
+var Te = binary.BigEndian
+
+type TestSuite struct {
+	t *packets.TCPHeader
+	u *packets.UDPHeader
+}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) SetUpTest(c *C) {
+	t.t = &packets.TCPHeader{
+		SourcePort:      44273,
+		DestinationPort: 22,
+		SeqNum:          42,
+		AckNum:          0,
+		Reserved:        0,
+		NS:              false,
+		CWR:             false,
+		ECE:             false,
+		URG:             false,
+		ACK:             false,
+		PSH:             true,
+		RST:             false,
+		SYN:             true,
+		FIN:             false,
+		WindowSize:      43690,
+		Checksum:        0,
+		UrgentPointer:   0,
+	}
+
+	udpPayload := make([]byte, 4)
+
+	udpPayload[0] = uint8(42)
+	udpPayload[1] = uint8(128)
+	udpPayload[2] = uint8(0)
+	udpPayload[3] = uint8(0)
+
+	t.u = &packets.UDPHeader{
+		SourcePort:      4242,
+		DestinationPort: 53,
+		Length:          12,
+		Checksum:        0,
+		Payload:         udpPayload,
+	}
+}
+
+func (t *TestSuite) TestChecksumIPv4(c *C) {
+	var csum uint16
+	var err error
+
+	rawBytes := new(bytes.Buffer)
+
+	// Source Port
+	binary.Write(rawBytes, Te, uint16(44273))
+	// Destination Port
+	binary.Write(rawBytes, Te, uint16(22))
+	// TCP Sequence Number
+	binary.Write(rawBytes, Te, uint32(42))
+	// Acknowledgement number
+	binary.Write(rawBytes, Te, uint32(0))
+
+	// Data offset (4 bits), Reserved (3 bits), NS, CWR, ECE,
+	// URG, ACK,
+	mix := uint16(5)<<12 | // Data Offset (4 bits)
+		uint16(0)<<9 | // Reserved (3 bits)
+		uint16(0)<<6 | // ECN (3 bits)
+		uint16(8) | // PSH (1 bit)
+		uint16(2) // SYN (1 bit)
+
+	binary.Write(rawBytes, Te, mix)
+
+	// Window Size
+	binary.Write(rawBytes, Te, uint16(43690))
+	// Checksum
+	binary.Write(rawBytes, Te, uint16(0))
+	// Urgent
+	binary.Write(rawBytes, Te, uint16(0))
+
+	csum, err = packets.ChecksumIPv4(rawBytes.Bytes(), "tcp", "127.0.0.1", "127.0.0.2")
+	c.Assert(err, IsNil)
+	c.Check(csum, Equals, uint16(0xfb59))
+
+	//
+	// TEST KIND UDP
+	//
+	rawBytes.Reset()
+
+	// Source Port
+	binary.Write(rawBytes, Te, uint16(44273))
+	// Destination Port
+	binary.Write(rawBytes, Te, uint16(22))
+	// TCP Sequence Number
+	binary.Write(rawBytes, Te, uint32(42))
+	// Acknowledgement number
+	binary.Write(rawBytes, Te, uint32(0))
+
+	// Data offset (4 bits), Reserved (3 bits), NS, CWR, ECE,
+	// URG, ACK,
+	binary.Write(rawBytes, Te, mix)
+
+	// Window Size
+	binary.Write(rawBytes, Te, uint16(43690))
+	// Checksum
+	binary.Write(rawBytes, Te, uint16(0))
+	// Urgent
+	binary.Write(rawBytes, Te, uint16(0))
+
+	csum, err = packets.ChecksumIPv4(rawBytes.Bytes(), "udp", "127.0.0.1", "127.0.0.2")
+	c.Assert(err, IsNil)
+	c.Check(csum, Equals, uint16(0xf059))
+
+	csum, err = packets.ChecksumIPv4(rawBytes.Bytes(), "invalid", "127.0.0.1", "127.0.0.2")
+	c.Assert(err, Not(IsNil))
+	c.Check(csum, Equals, uint16(0))
+
+	switch err.(type) {
+	case packets.ErrChecksumInvalidKind:
+		c.Check(err.Error(), Equals, "Checksum kind should either be 'tcp' OR 'udp'.")
+	default:
+		c.Fatalf("error type should be packets.ErrChecksumInvalidKind was %s", reflect.TypeOf(err).String())
+	}
+}

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -8,43 +8,10 @@ import (
 	"bytes"
 	"encoding/binary"
 	"reflect"
-	"testing"
 
 	"github.com/theckman/packets"
 	. "gopkg.in/check.v1"
 )
-
-var Te = binary.BigEndian
-
-type TestSuite struct {
-	t *packets.TCPHeader
-}
-
-var _ = Suite(&TestSuite{})
-
-func Test(t *testing.T) { TestingT(t) }
-
-func (t *TestSuite) SetUpTest(c *C) {
-	t.t = &packets.TCPHeader{
-		SourcePort:      44273,
-		DestinationPort: 22,
-		SeqNum:          42,
-		AckNum:          0,
-		Reserved:        0,
-		NS:              false,
-		CWR:             false,
-		ECE:             false,
-		URG:             false,
-		ACK:             false,
-		PSH:             true,
-		RST:             false,
-		SYN:             true,
-		FIN:             false,
-		WindowSize:      43690,
-		Checksum:        0,
-		UrgentPointer:   0,
-	}
-}
 
 func (t *TestSuite) TestTCPOptionSlice_Marshal(c *C) {
 	var data []byte
@@ -291,41 +258,6 @@ func (t *TestSuite) TestUnmarshalTCPHeader(c *C) {
 	c.Check(header.Options[1].Kind, Equals, uint8(4))
 	c.Check(header.Options[1].Length, Equals, uint8(2))
 	c.Check(len(header.Options[1].Data), Equals, 0)
-}
-
-func (t *TestSuite) TestChecksumIPv4(c *C) {
-	var csum uint16
-
-	rawBytes := new(bytes.Buffer)
-
-	// Source Port
-	binary.Write(rawBytes, Te, uint16(44273))
-	// Destination Port
-	binary.Write(rawBytes, Te, uint16(22))
-	// TCP Sequence Number
-	binary.Write(rawBytes, Te, uint32(42))
-	// Acknowledgement number
-	binary.Write(rawBytes, Te, uint32(0))
-
-	// Data offset (4 bits), Reserved (3 bits), NS, CWR, ECE,
-	// URG, ACK,
-	mix := uint16(5)<<12 | // Data Offset (4 bits)
-		uint16(0)<<9 | // Reserved (3 bits)
-		uint16(0)<<6 | // ECN (3 bits)
-		uint16(8) | // PSH (1 bit)
-		uint16(2) // SYN (1 bit)
-
-	binary.Write(rawBytes, Te, mix)
-
-	// Window Size
-	binary.Write(rawBytes, Te, uint16(43690))
-	// Checksum
-	binary.Write(rawBytes, Te, uint16(0))
-	// Urgent
-	binary.Write(rawBytes, Te, uint16(0))
-
-	csum = packets.ChecksumIPv4(rawBytes.Bytes(), "127.0.0.1", "127.0.0.2")
-	c.Check(csum, Equals, uint16(0xfb59))
 }
 
 func (t *TestSuite) TestTCPHeader_Marshal(c *C) {

--- a/udp.go
+++ b/udp.go
@@ -1,0 +1,160 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package packets
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+const (
+	udpHeaderLen int = 8
+	maxUint16    int = int(^uint16(0))
+)
+
+// UDPHeader is the struct representing a UDP header.
+type UDPHeader struct {
+	SourcePort      uint16
+	DestinationPort uint16
+	Length          uint16 // if set to zero it will be automatically set
+	Checksum        uint16
+	Payload         []byte
+}
+
+// UnmarshalUDPHeader is a function that takes a byte slice anf formats it in to an
+// instance of *UDPHeader. This also assumes the packet is properly formatted.
+func UnmarshalUDPHeader(data []byte) (*UDPHeader, error) {
+	return unmarshalUDPHeader(data)
+}
+
+// Marshal is a function to marshal the *UDPHeader instance to a byte slice
+// without explicitly calculating the checkum for the data.
+//
+// To note, if the checksum is not provided (i.e., 0) the kernel SHOULD automatically
+// calculate this for you.
+//
+// If the Checksum field is set, it will be included in the marshaled data.
+func (udp *UDPHeader) Marshal() ([]byte, error) {
+	return udp.marshalUDPHeader()
+}
+
+// MarshalWithChecksum is a function to marshal the *UDPHeader instance to a byte
+// slice including the calculation of the Checksum field.
+//
+// It's suggested that you use Marshal() instead and offload the checksumming
+// to your kernel (which should do it automatically if field is zero)
+//
+// Because of the requirement to create a pseudoheader to do the checksumming the
+// local IPv4 address and remote IPv4 address must be provided in string form.
+func (udp *UDPHeader) MarshalWithChecksum(laddr, raddr string) ([]byte, error) {
+	// marshal the header
+	data, err := udp.marshalUDPHeader()
+
+	if err != nil {
+		return nil, err
+	}
+
+	csum, err := ChecksumIPv4(data, "udp", laddr, raddr)
+	if err != nil {
+		return nil, err
+	}
+
+	udp.Checksum = csum
+
+	// remarshal again, with proper Checksum this time
+	data, err = udp.marshalUDPHeader()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func unmarshalUDPHeader(data []byte) (*UDPHeader, error) {
+	var header UDPHeader
+
+	reader := bytes.NewReader(data)
+
+	err := binary.Read(reader, binary.BigEndian, &header.SourcePort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.DestinationPort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.Length)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Read(reader, binary.BigEndian, &header.Checksum)
+	if err != nil {
+		return nil, err
+	}
+
+	bytesToRead := int(header.Length) - udpHeaderLen
+
+	payload := make([]byte, bytesToRead)
+
+	err = binary.Read(reader, binary.BigEndian, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	header.Payload = payload
+
+	return &header, nil
+}
+
+func (udp *UDPHeader) marshalUDPHeader() ([]byte, error) {
+	packetSize := len(udp.Payload) + udpHeaderLen
+
+	if packetSize > maxUint16 {
+		return nil, ErrUDPPayloadTooLarge{
+			E: fmt.Sprintf(
+				"UDP Payload must not be larger than %d byte, was %d bytes",
+				maxUint16-udpHeaderLen, len(udp.Payload),
+			),
+		}
+	}
+
+	if udp.Length == 0 {
+		udp.Length = uint16(packetSize)
+	}
+
+	buf := new(bytes.Buffer)
+
+	err := binary.Write(buf, binary.BigEndian, udp.SourcePort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(buf, binary.BigEndian, udp.DestinationPort)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(buf, binary.BigEndian, udp.Length)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(buf, binary.BigEndian, udp.Checksum)
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(buf, binary.BigEndian, udp.Payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}

--- a/udp_test.go
+++ b/udp_test.go
@@ -1,0 +1,124 @@
+// Copyright 2015 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package packets_test
+
+import (
+	"bytes"
+	"encoding/binary"
+
+	"github.com/theckman/packets"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestUnmarshalUDPHeader(c *C) {
+	var header *packets.UDPHeader
+	var err error
+
+	buf := new(bytes.Buffer)
+
+	// SourcePort
+	binary.Write(buf, Te, uint16(4242))
+	// DestinationPort
+	binary.Write(buf, Te, uint16(53))
+	// Length
+	binary.Write(buf, Te, uint16(12))
+	// Checksum
+	binary.Write(buf, Te, uint16(0))
+
+	// Imaginary Payload
+	binary.Write(buf, Te, uint8(42))
+	binary.Write(buf, Te, uint8(128))
+	binary.Write(buf, Te, uint8(0))
+	binary.Write(buf, Te, uint8(0))
+
+	header, err = packets.UnmarshalUDPHeader(buf.Bytes())
+	c.Assert(err, IsNil)
+	c.Assert(header, Not(IsNil))
+
+	c.Check(header.SourcePort, Equals, uint16(4242))
+	c.Check(header.DestinationPort, Equals, uint16(53))
+	c.Check(header.Length, Equals, uint16(12))
+	c.Check(header.Checksum, Equals, uint16(0))
+
+	c.Assert(len(header.Payload), Equals, 4)
+	c.Check(header.Payload[0], Equals, uint8(42))
+	c.Check(header.Payload[1], Equals, uint8(128))
+	c.Check(header.Payload[2], Equals, uint8(0))
+	c.Check(header.Payload[3], Equals, uint8(0))
+}
+
+func (t *TestSuite) TestUDPHeader_Marshal(c *C) {
+	var data []byte
+	var err error
+
+	data, err = t.u.Marshal()
+	c.Assert(err, IsNil)
+	c.Assert(data, Not(IsNil))
+
+	var u16 uint16
+	var u8 uint8
+
+	r := bytes.NewReader(data)
+
+	// SourcePort
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(4242))
+	// DestinationPort
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(53))
+	// Length
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(12))
+	// Checksum
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(0))
+
+	// Payload
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(42))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(128))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(0))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(0))
+}
+
+func (t *TestSuite) TestUDPHeader_MarshalWithChecksum(c *C) {
+	var data []byte
+	var err error
+
+	data, err = t.u.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
+	c.Assert(err, IsNil)
+	c.Assert(data, Not(IsNil))
+
+	var u16 uint16
+	var u8 uint8
+
+	r := bytes.NewReader(data)
+
+	// SourcePort
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(4242))
+	// DestinationPort
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(53))
+	// Length
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(12))
+	// Checksum
+	c.Assert(binary.Read(r, Te, &u16), IsNil)
+	c.Check(u16, Equals, uint16(35782))
+
+	// Payload
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(42))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(128))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(0))
+	c.Assert(binary.Read(r, Te, &u8), IsNil)
+	c.Check(u8, Equals, uint8(0))
+}


### PR DESCRIPTION
This adds the ability to marshal and unmarshal UDP packets. In addition, the ChecksumIPv4 function was altered to incldue passing whether it's tcp or udp.
