### PR TITLE
make error passing more idiomatic

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -4,77 +4,75 @@
 
 package packets
 
-// ErrTCPDataOffsetInvalid is a type that implements the error interface. It's used for errors
-// marshaling the TCPHeader data. You can type assert against it to handle that input
-// differently.
-type ErrTCPDataOffsetInvalid struct {
-	E string
-}
+import (
+	"errors"
+	"fmt"
+)
 
-func (e ErrTCPDataOffsetInvalid) Error() string {
-	return e.E
-}
+// ErrTCPDataOffsetInvalid is a type that implements the error interface. It's used for errors
+// marshaling the TCPHeader data.
+var ErrTCPDataOffsetInvalid = errors.New("DataOffset field must be at least 5 and no more than 15")
+
+// ErrChecksumInvalidKind is a type that implements the error interface. It's used when
+// an invalid packet kind is provided to the ChecksumIPv4 function.
+var ErrChecksumInvalidKind = errors.New("Checksum kind should either be 'tcp' OR 'udp'.")
 
 // ErrTCPDataOffsetTooSmall is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the DataOffset is too small
 // for the amount of data in the TCP header.
 type ErrTCPDataOffsetTooSmall struct {
-	E string
+	ExpectedSize uint8
 }
 
 func (e ErrTCPDataOffsetTooSmall) Error() string {
-	return e.E
+	return fmt.Sprintf(
+		"The DataOffset field is too small for the data provided. It should be at least %d",
+		e.ExpectedSize,
+	)
 }
 
 // ErrTCPOptionsOverflow is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the TCP Options field exceeds
 // its maximum length as specified by the RFC.
 type ErrTCPOptionsOverflow struct {
-	E string
+	MaxSize int
 }
 
 func (e ErrTCPOptionsOverflow) Error() string {
-	return e.E
+	return fmt.Sprintf("TCP Options are too large, must be less than %d total bytes", e.MaxSize)
 }
 
 // ErrTCPOptionDataInvalid is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is used when the TCP Options Length field
 // doesn't match the data provided.
 type ErrTCPOptionDataInvalid struct {
-	E string
+	Index int
 }
 
 func (e ErrTCPOptionDataInvalid) Error() string {
-	return e.E
+	return fmt.Sprintf("Option %d Length doesn't match length of data", e.Index)
 }
 
 // ErrTCPOptionDataTooLong is a type that implements the error interface. It's used for errors
 // marshaling the TCPHeader data. Specifically, this is use for when the TCP Options Data field is
 // too long for the Options field as per the RFC.
 type ErrTCPOptionDataTooLong struct {
-	E string
+	Index int
 }
 
 func (e ErrTCPOptionDataTooLong) Error() string {
-	return e.E
+	return fmt.Sprintf("Option %d Data cannot be larger than 253 bytes", e.Index)
 }
 
 // ErrUDPPayloadTooLarge is a type that implements the error interface. It's used for errors
 // marshaling the UDPHeader data. Specifically, this is use for when the UDP payload is too large.
 type ErrUDPPayloadTooLarge struct {
-	E string
+	MaxSize, Len int
 }
 
 func (e ErrUDPPayloadTooLarge) Error() string {
-	return e.E
-}
-
-// ErrChecksumInvalidKind is a type that implements the error interface. It's used when
-// an invalid packet kind is provided to the ChecksumIPv4 function.
-type ErrChecksumInvalidKind struct {
-	E string
-}
-
-func (e ErrChecksumInvalidKind) Error() string {
-	return e.E
+	return fmt.Sprintf(
+		"UDP Payload must not be larger than %d byte, was %d bytes",
+		e.MaxSize, e.Len,
+	)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -10,41 +10,52 @@ import (
 )
 
 func (t *TestSuite) TestErrTCPDataOffsetInvalid_Error(c *C) {
-	var e packets.ErrTCPDataOffsetInvalid
+	c.Check(packets.ErrTCPDataOffsetInvalid.Error(), Equals, "DataOffset field must be at least 5 and no more than 15")
+}
 
-	e = packets.ErrTCPDataOffsetInvalid{E: "test message"}
-
-	c.Assert(e.Error(), Equals, "test message")
+func (t *TestSuite) TestErrChecksumInvalidKind_Error(c *C) {
+	c.Check(packets.ErrChecksumInvalidKind.Error(), Equals, "Checksum kind should either be 'tcp' OR 'udp'.")
 }
 
 func (t *TestSuite) TestErrTCPDataOffsetTooSmall_Error(c *C) {
 	var e packets.ErrTCPDataOffsetTooSmall
 
-	e = packets.ErrTCPDataOffsetTooSmall{E: "test message"}
+	e = packets.ErrTCPDataOffsetTooSmall{ExpectedSize: 100}
 
-	c.Assert(e.Error(), Equals, "test message")
+	c.Check(e.Error(), Equals, "The DataOffset field is too small for the data provided. It should be at least 100")
 }
 
 func (t *TestSuite) TestErrTCPOptionsOverflow_Error(c *C) {
 	var e packets.ErrTCPOptionsOverflow
 
-	e = packets.ErrTCPOptionsOverflow{E: "test message"}
+	e = packets.ErrTCPOptionsOverflow{MaxSize: 100}
 
-	c.Assert(e.Error(), Equals, "test message")
+	c.Check(e.Error(), Equals, "TCP Options are too large, must be less than 100 total bytes")
 }
 
 func (t *TestSuite) TestErrTCPOptionDataInvalid_Error(c *C) {
 	var e packets.ErrTCPOptionDataInvalid
 
-	e = packets.ErrTCPOptionDataInvalid{E: "test message"}
+	e = packets.ErrTCPOptionDataInvalid{Index: 42}
 
-	c.Assert(e.Error(), Equals, "test message")
+	c.Check(e.Error(), Equals, "Option 42 Length doesn't match length of data")
 }
 
 func (t *TestSuite) TestErrTCPOptionDataTooLong_Error(c *C) {
 	var e packets.ErrTCPOptionDataTooLong
 
-	e = packets.ErrTCPOptionDataTooLong{E: "test message"}
+	e = packets.ErrTCPOptionDataTooLong{Index: 42}
 
-	c.Assert(e.Error(), Equals, "test message")
+	c.Check(e.Error(), Equals, "Option 42 Data cannot be larger than 253 bytes")
+}
+
+func (t *TestSuite) TestErrUDPPayloadTooLarge_Error(c *C) {
+	var e packets.ErrUDPPayloadTooLarge
+
+	e = packets.ErrUDPPayloadTooLarge{
+		MaxSize: 42,
+		Len:     84,
+	}
+
+	c.Check(e.Error(), Equals, "UDP Payload must not be larger than 42 byte, was 84 bytes")
 }

--- a/packets.go
+++ b/packets.go
@@ -22,9 +22,7 @@ func ChecksumIPv4(data []byte, kind, laddr, raddr string) (uint16, error) {
 	case "udp", "UDP":
 		protocol = 17
 	default:
-		return 0, ErrChecksumInvalidKind{
-			E: "Checksum kind should either be 'tcp' OR 'udp'.",
-		}
+		return 0, ErrChecksumInvalidKind
 	}
 
 	// create a pseudo header for the packet checksumming

--- a/packets_test.go
+++ b/packets_test.go
@@ -7,7 +7,6 @@ package packets_test
 import (
 	"bytes"
 	"encoding/binary"
-	"reflect"
 	"testing"
 
 	"github.com/theckman/packets"
@@ -130,11 +129,5 @@ func (t *TestSuite) TestChecksumIPv4(c *C) {
 	csum, err = packets.ChecksumIPv4(rawBytes.Bytes(), "invalid", "127.0.0.1", "127.0.0.2")
 	c.Assert(err, Not(IsNil))
 	c.Check(csum, Equals, uint16(0))
-
-	switch err.(type) {
-	case packets.ErrChecksumInvalidKind:
-		c.Check(err.Error(), Equals, "Checksum kind should either be 'tcp' OR 'udp'.")
-	default:
-		c.Fatalf("error type should be packets.ErrChecksumInvalidKind was %s", reflect.TypeOf(err).String())
-	}
+	c.Check(err, Equals, packets.ErrChecksumInvalidKind)
 }

--- a/tcp_test.go
+++ b/tcp_test.go
@@ -90,6 +90,7 @@ func (t *TestSuite) TestTCPOptionSlice_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPOptionDataTooLong:
+		c.Check(err.(packets.ErrTCPOptionDataTooLong).Index, Equals, 0)
 		c.Check(err.Error(), Equals, "Option 0 Data cannot be larger than 253 bytes")
 	default:
 		c.Fatalf("error type should be packets.ErrTCPOptionDataTooLarge was %s", reflect.TypeOf(err).String())
@@ -107,6 +108,7 @@ func (t *TestSuite) TestTCPOptionSlice_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPOptionDataInvalid:
+		c.Check(err.(packets.ErrTCPOptionDataInvalid).Index, Equals, 0)
 		c.Check(err.Error(), Equals, "Option 0 Length doesn't match length of data")
 	default:
 		c.Fatalf("error type should be packets.ErrTCPOptionDataInvalid was %s", reflect.TypeOf(err).String())
@@ -520,6 +522,7 @@ func (t *TestSuite) TestTCPHeader_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPOptionDataTooLong:
+		c.Check(err.(packets.ErrTCPOptionDataTooLong).Index, Equals, 0)
 		c.Check(err.Error(), Equals, "Option 0 Data cannot be larger than 253 bytes")
 	default:
 		c.Fatalf("error type should be packets.ErrTCPOptionDataTooLarge was %s", reflect.TypeOf(err).String())
@@ -551,6 +554,7 @@ func (t *TestSuite) TestTCPHeader_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPOptionDataInvalid:
+		c.Check(err.(packets.ErrTCPOptionDataInvalid).Index, Equals, 0)
 		c.Check(err.Error(), Equals, "Option 0 Length doesn't match length of data")
 	default:
 		c.Fatalf("error type should be packets.ErrTCPOptionDataInvalid was %s", reflect.TypeOf(err).String())
@@ -582,9 +586,10 @@ func (t *TestSuite) TestTCPHeader_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPOptionsOverflow:
+		c.Check(err.(packets.ErrTCPOptionsOverflow).MaxSize, Equals, 40)
 		c.Check(err.Error(), Equals, "TCP Options are too large, must be less than 40 total bytes")
 	default:
-		c.Fatalf("error type should be packets.ErrTCPOptionDataInvalid was %s", reflect.TypeOf(err).String())
+		c.Fatalf("error type should be packets.ErrTCPOptionsOverflow was %s", reflect.TypeOf(err).String())
 	}
 
 	//
@@ -612,6 +617,7 @@ func (t *TestSuite) TestTCPHeader_Marshal(c *C) {
 
 	switch err.(type) {
 	case packets.ErrTCPDataOffsetTooSmall:
+		c.Check(err.(packets.ErrTCPDataOffsetTooSmall).ExpectedSize, Equals, uint8(6))
 		c.Check(err.Error(), Equals, "The DataOffset field is too small for the data provided. It should be at least 6")
 	default:
 		c.Fatalf("error type should be packets.ErrTCPDataOffsetTooSmall type was %s", reflect.TypeOf(err).String())
@@ -739,13 +745,7 @@ func (t *TestSuite) TestTCPHeader_MarshalWithChecksum(c *C) {
 	data, err = t.t.MarshalWithChecksum("127.0.0.1", "127.0.0.2")
 	c.Assert(err, Not(IsNil))
 	c.Check(data, IsNil)
-
-	switch err.(type) {
-	case packets.ErrTCPDataOffsetInvalid:
-		c.Check(err.Error(), Equals, "DataOffset field must be at least 5 and no more than 15")
-	default:
-		c.Fatalf("error type should be packets.ErrTCPDataOffsetInvalid was %s", reflect.TypeOf(err).String())
-	}
+	c.Check(err, Equals, packets.ErrTCPDataOffsetInvalid)
 
 	//
 	// TEST WHEN WindowSize IS ZERO

--- a/udp.go
+++ b/udp.go
@@ -7,7 +7,6 @@ package packets
 import (
 	"bytes"
 	"encoding/binary"
-	"fmt"
 )
 
 const (
@@ -118,10 +117,8 @@ func (udp *UDPHeader) marshalUDPHeader() ([]byte, error) {
 
 	if packetSize > maxUint16 {
 		return nil, ErrUDPPayloadTooLarge{
-			E: fmt.Sprintf(
-				"UDP Payload must not be larger than %d byte, was %d bytes",
-				maxUint16-udpHeaderLen, len(udp.Payload),
-			),
+			MaxSize: maxUint16 - udpHeaderLen,
+			Len:     len(udp.Payload),
 		}
 	}
 


### PR DESCRIPTION
This makes the errors we use in the `packets` library more idiomatic. Errors that took variables have been modified so that the variables themselves are given to the type instead of a prebuilt string. This allows consumers to pull information from the error instead of doing some sort of regex match on the string.

For error types that took no variable data, they've been converted to variables on the `packets` package using `errors.New()`. The actual error messages never changed, so it made no sense to make these their own type.

Lastly, some specs were added for...
- `ErrChecksumInvalidKind`
- `ErrUDPPayloadTooLarge`
